### PR TITLE
Fault manager

### DIFF
--- a/site_scons/site_init.py
+++ b/site_scons/site_init.py
@@ -73,13 +73,11 @@ def TOOL_DBCC(env):
     """
 
     """
-    -k for only generating pack code- BMS does not have a need to read CAN data
-
     SOURCE - dbc file node
     TARGET - c file node that will be generated. The directory of this file will be used in the command.
     """
     dbcc_builder = SCons.Builder.Builder(action=[
-        DBCC_DIR.abspath + '/dbcc -o ${TARGET.dir.abspath} -k ${SOURCE}'
+        DBCC_DIR.abspath + '/dbcc -o ${TARGET.dir.abspath} ${SOURCE}'
     ])
 
     env.Append(BUILDERS = {

--- a/src/app/CurrentMonitor/CurrentMonitor.c
+++ b/src/app/CurrentMonitor/CurrentMonitor.c
@@ -19,12 +19,7 @@ void CurrentMonitor_1kHz(float current_A)
     {
         if (counter_incr(&time_overcurrent_ms, OVERCURRENT_HYST_MS))
         {
-            char fault_data[ERROR_DATA_LEN];
-
-            // convert float to incremental value for CAN
-            uint32_t fault_current = (current_A  + 0.0005) / 0.001;
-            STORE_BIG_ENDIAN(fault_data, fault_current, sizeof(uint32_t));
-            FaultManager_set_fault_active(FaultCode_OVER_CURRENT, fault_data, true);
+            FaultManager_set_fault_active(FaultCode_OVER_CURRENT, &current_A);
         }
     }
     else

--- a/src/app/CurrentSense/CurrentSense.c
+++ b/src/app/CurrentSense/CurrentSense.c
@@ -49,7 +49,7 @@ void CurrentSense_1kHz(void)
     if (err.active)
     {
         did_last_read_error = true;
-        FaultManager_set_fault_active(FaultCode_CURRENT_SENSOR_COMM, err.data, false);
+        FaultManager_set_fault_active(FaultCode_CURRENT_SENSOR_COMM, err.data);
     }
     else
     {

--- a/src/app/FaultManager/FaultManager.c
+++ b/src/app/FaultManager/FaultManager.c
@@ -1,32 +1,87 @@
-// #include "FaultManager.h"
+#include <stdint.h>
 
-// // Status of a fault
-// typedef enum
-// {
-//     CLEAR,
-//     ACTIVE,
-//     LATCHED
-// } FaultStatus_e;
+#include "common_macros.h"
+#include "CAN.h"
+#include "FaultManager.h"
 
-// // An array with an element for each fault indicating the status of the fault.
-// static FaultStatus_e FAULT_STATUS[FaultCode_NUM];
+/**
+ * Each bit represents fault status.
+ * 1 for active
+ * 0 for inactive.
+ * 
+ * Fault bits are indexed using the FaultCode_e enum values.
+ */
+static uint64_t fault_vector;
 
-// void FaultManager_set_fault_active(Fault_t fault, bool latch)
-// {
-//     // set the fault
-//     if (latch)
-//     {
-//         FAULT_STATUS[fault.code] = LATCHED;
-//     }
-//     else
-//     {
-//         FAULT_STATUS[fault.code] = ACTIVE;
-//     }
+void FaultManager_init(void)
+{
+    // zero out every fault/latch bit
+    fault_vector = 0;
 
-//     // TODO- Send the CAN alert
-// }
+    // initialize the fault vector CAN message
+    unpack_message(&CAN_BUS, CAN_ID_BmsFaultVector, fault_vector, 8, 0);
+}
 
-// bool FaultManager_is_fault_active(FaultCode_e code)
-// {
-//     return FAULT_STATUS[code] == ACTIVE || FAULT_STATUS[code] == LATCHED;
-// }
+// TODO- use mutex around faultvector
+void FaultManager_set_fault_active(FaultCode_e code, void* data)
+{
+    // set the fault
+    fault_vector |= BIT(code);
+
+    // set the CAN alert data field accordingly
+    switch(code)
+    {
+        case FaultCode_OVER_CURRENT:
+            encode_can_0x2bd_BmsFaultAlert_current(&CAN_BUS, *((float*)data));
+            break;
+        
+        case FaultCode_SLAVE_COMM_CELLS:
+            encode_can_0x2bd_BmsFaultAlert_cell_comm_slave_board_num(&CAN_BUS, *((uint8_t*)data));
+            break;
+        
+        case FaultCode_SLAVE_COMM_TEMPS:
+            encode_can_0x2bd_BmsFaultAlert_temp_comm_slave_board_num(&CAN_BUS, *((uint8_t*)data));
+            break;
+
+        case FaultCode_SLAVE_COMM_DRAIN_REQUEST:
+            encode_can_0x2bd_BmsFaultAlert_drain_comm_slave_board_num(&CAN_BUS, *((uint8_t*)data));
+            break;
+
+        case FaultCode_CURRENT_SENSOR_COMM:
+            encode_can_0x2bd_BmsFaultAlert_adc_error_code(&CAN_BUS, *((uint8_t*)data));
+            break;
+        
+        default:
+            // send garbage data
+            break;
+    }
+
+    // set the mux of the alert message to the fault code
+    encode_can_0x2bd_BmsFaultAlert_code(&CAN_BUS, (uint8_t)code);
+
+    CAN_send_message(CAN_ID_BmsFaultAlert);
+
+    // update the fault vector CAN message data
+    unpack_message(&CAN_BUS, CAN_ID_BmsFaultVector, fault_vector, 8, 0);
+}
+
+// TODO- use mutex around faultvector
+void FaultManager_clear_fault(FaultCode_e code)
+{
+    uint64_t temp_fault_vector = fault_vector;
+
+    // clear the fault bit
+    temp_fault_vector &= ~BIT(code);
+
+    // atomically? set the fault vector
+    // this is only atomic if the stm32 supports 64 bit instructions...
+    fault_vector = temp_fault_vector;
+
+    // update the fault vector CAN message data
+    unpack_message(&CAN_BUS, CAN_ID_BmsFaultVector, fault_vector, 8, 0);
+}
+
+bool FaultManager_is_fault_active(FaultCode_e code)
+{
+    return (fault_vector & BIT(code)) != 0;
+}

--- a/src/app/FaultManager/test_FaultManager.c
+++ b/src/app/FaultManager/test_FaultManager.c
@@ -1,3 +1,85 @@
+#include <stdio.h>
+
 #include "unity.h"
 
-// Todo- implement this lol
+#include "FaultManager.h"
+
+#include "MockCAN.h"
+
+// need to define this here since CMock isn't smart enough to define it in MockCAN.h
+can_obj_f29bms_dbc_h_t CAN_BUS;
+
+void setUp(void)
+{
+    FaultManager_init();
+}
+
+/**
+ * Check that no faults are active at startup.
+ */
+void test_FaultManager_start_no_faults(void)
+{
+    for (int code = 0; code < FaultCode_NUM; code++)
+    {
+        char err_msg[50];
+        sprintf(err_msg, "Fault code %d active at start.", code);
+        TEST_ASSERT_MESSAGE(FaultManager_is_fault_active(code) == false, err_msg);
+    }
+}
+
+/**
+ * Test that faults are reported as active after being set and inactive after
+ * being cleared.
+ */
+void test_FaultManager_fault_and_clear(void)
+{
+    float unused_fault_data = 42;
+    char err_msg[70];
+
+    // check that each fault sets correctly and the state of faults is consistent
+    // this is important since FaultManager uses a bitwise implementation that is prone to overwrite events
+    for (int code = 0; code < FaultCode_NUM; code++)
+    {
+        // make sure each fault sets correctly
+        CAN_send_message_ExpectAnyArgs();
+        FaultManager_set_fault_active(code, &unused_fault_data);
+        sprintf(err_msg, "Fault code %d failed to set.", code);
+        TEST_ASSERT_MESSAGE(FaultManager_is_fault_active(code) == true,  err_msg);
+
+        // make sure no other faults were cleared
+        for (int code2 = 0; code2 < code; code2++)
+        {
+            sprintf(err_msg, "Fault code %d was cleared after setting code %d.", code2, code);
+            TEST_ASSERT_MESSAGE(FaultManager_is_fault_active(code2) == true, err_msg);
+        }
+
+        // make sure no other faults were set
+        for (int code2 = code + 1; code2 < FaultCode_NUM; code2++)
+        {
+            sprintf(err_msg, "Fault code %d was set after setting code %d.", code2, code);
+            TEST_ASSERT_MESSAGE(FaultManager_is_fault_active(code2) == false, err_msg);
+        }
+    }
+    
+    // check that each fault clears correctly and the state of faults is consistent
+    for (int code = 0; code < FaultCode_NUM; code++)
+    {
+        FaultManager_clear_fault(code);
+        sprintf(err_msg, "Fault code %d failed to clear.", code);
+        TEST_ASSERT_MESSAGE(FaultManager_is_fault_active(code) == false, err_msg);
+
+        // make sure no other faults were cleared
+        for (int code2 = code + 1; code2 < FaultCode_NUM; code2++)
+        {
+            sprintf(err_msg, "Fault code %d was cleared after clearing code %d.", code2, code);
+            TEST_ASSERT_MESSAGE(FaultManager_is_fault_active(code2) == true, err_msg);
+        }
+
+        // make sure no other faults were set
+        for (int code2 = 0; code2 < code; code2++)
+        {
+            sprintf(err_msg, "Fault code %d was set after clearing code %d.", code2, code);
+            TEST_ASSERT_MESSAGE(FaultManager_is_fault_active(code2) == false, err_msg);
+        }
+    }
+}

--- a/src/app/SlaveInterface/SlaveInterface.c
+++ b/src/app/SlaveInterface/SlaveInterface.c
@@ -19,7 +19,7 @@ void SlaveInterface_read_cell_info(BatteryModel_t* battery_model)
     // check for comm errors
     if (err.active)
     {
-        FaultManager_set_fault_active(FaultCode_SLAVE_COMM_CELLS, err.data, false);
+        FaultManager_set_fault_active(FaultCode_SLAVE_COMM_CELLS, err.data);
     }  
     else
     {
@@ -48,7 +48,7 @@ void SlaveInterface_read_temperature_info(TempModel_t* temp_model)
     // check for communication errors
     if (err.active)
     {
-        FaultManager_set_fault_active(FaultCode_SLAVE_COMM_TEMPS, err.data, false);
+        FaultManager_set_fault_active(FaultCode_SLAVE_COMM_TEMPS, err.data);
     }
     else
     {
@@ -79,7 +79,7 @@ void SlaveInterface_request_cell_draining(BatteryModel_t* battery_model)
 
     if (err.active)
     {
-        FaultManager_set_fault_active(FaultCode_SLAVE_COMM_DRAIN_REQUEST, err.data, false);
+        FaultManager_set_fault_active(FaultCode_SLAVE_COMM_DRAIN_REQUEST, err.data);
     }
     else
     {

--- a/src/common/common_macros.h
+++ b/src/common/common_macros.h
@@ -1,14 +1,16 @@
 #ifndef COMMON_MACROS_H
 #define COMMON_MACROS_H
 
+// math
 #define MAX(x, y) (x < y ? y : x)
 #define MIN(x, y) (x < y ? x : y)
 #define SAT(v, x, y) MIN(MAX(v, x), y)
-
-#define ISOLATE_BYTE(value, byte) ((value & (0xFF << (byte * 8))) >> (byte * 8))
-#define STORE_BIG_ENDIAN(arr, value, len) for (int i = 0; i < len; i++) arr[i] = ISOLATE_BYTE(value, len-1-i);
-#define STORE_LITTLE_ENDIAN(arr, value, len) for (int i = 0; i < len; i++) arr[i] = ISOLATE_BYTE(value, i);
-
 #define ROUND_2D(v) ((float)((float)((int)(v * 100 + .5))) / 100)
+
+// bitwise stuff
+#define BIT(x) (1 << (x))
+#define ISOLATE_BYTE(value, byte) (((value) & (0xFF << ((byte) * 8))) >> ((byte) * 8))
+#define STORE_BIG_ENDIAN(arr, value, len) for (int i = 0; i < (len); i++) arr[i] = ISOLATE_BYTE((value), (len)-1-i);
+#define STORE_LITTLE_ENDIAN(arr, value, len) for (int i = 0; i < (len); i++) arr[i] = ISOLATE_BYTE((value), i);
 
 #endif // COMMON_MACROS_H


### PR DESCRIPTION
The FaultManager is a simple module that is most basically a setter/getter for faults, but also provides other functionality: CAN alerts and latching. When a fault is set, a CAN alert is immediately sent by FaultManager. This functionality helps when debugging CAN traces with faults involved, since the precise timing of the fault can be more closely determined. Application code may choose to latch a fault when setting it, which prevents it from being cleared. This can be used to prevent retries during fault conditions to limit hardware damage.

Unit tests:
-Ensures no faults start active
-Sets/Clears each fault and checks for other faults erroneously set/cleared at the same time
-Tests latching functionality for each fault code