### PR TITLE
Drive monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.o
 *.hex
 *.elf
+**/mocks

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
 
-scons test-apps unit-tests -j4
+scons test-apps unit-tests -j4 -s

--- a/src/app/CurrentMonitor/CurrentMonitor.c
+++ b/src/app/CurrentMonitor/CurrentMonitor.c
@@ -17,7 +17,7 @@ void CurrentMonitor_1kHz(float current_A)
 {
     if ((current_A >= OVERCURRENT_A) || (current_A <= OVERCURRENT_CHG_A))
     {
-        if (counter_incr(&time_overcurrent_ms, OVERCURRENT_HYST_MS))
+        if (incr_to_limit(&time_overcurrent_ms, OVERCURRENT_HYST_MS))
         {
             FaultManager_set_fault_active(FaultCode_OVER_CURRENT, &current_A);
         }
@@ -26,7 +26,7 @@ void CurrentMonitor_1kHz(float current_A)
     {
         // clear fault if the overcurrent condition has been gone
         // for the time hysteresis
-        if (counter_decr(&time_overcurrent_ms, 0))
+        if (decr_to_limit(&time_overcurrent_ms, 0))
         {
             FaultManager_clear_fault(FaultCode_OVER_CURRENT);
         }

--- a/src/app/DriveMonitor/DriveMonitor.c
+++ b/src/app/DriveMonitor/DriveMonitor.c
@@ -1,0 +1,100 @@
+#include <stdint.h>
+#include <limits.h>
+
+#include "counters.h"
+
+#include "DriveMonitor.h"
+#include "FaultManager.h"
+#include "ShutdownLine.h"
+
+/**
+ * How many milliseconds each fault type is allowed to be active before triggering a shutdown.
+ * 
+ * This could be set statically, but its nice to define things at runtime in case FaultCode_e changes.
+ */
+static uint32_t fault_tolerances[FaultCode_NUM];
+
+/**
+ * How long each fault has been active in milliseconds.
+ */
+static int active_fault_timers[FaultCode_NUM];
+
+/**
+ * Keeps track of the last decision of DriveMonitor_1kHz of whether to shutdown or not.
+ */
+static bool is_driving_allowed;
+
+
+void DriveMonitor_init(void)
+{
+    // Default tolerances to safe value (0 for no tolerance).
+    // Start timers at 0
+    for (int i = 0; i < FaultCode_NUM; i++)
+    {
+        fault_tolerances[i] = 0;
+        active_fault_timers[i] = 0;
+    }
+
+    // Fault tolerance defition is here, in milliseconds.
+    // Any faults not defined here get 0, which means car will not drive until the
+    // devloper who added the fault code but didn't add a tolerance gets their act together. 
+    // Use 1 for faults that trigger shutdown if they're active at all.
+    fault_tolerances[FaultCode_SLAVE_COMM_CELLS]            = 10000;
+    fault_tolerances[FaultCode_SLAVE_COMM_TEMPS]            = 10000;
+    fault_tolerances[FaultCode_SLAVE_COMM_DRAIN_REQUEST]    = 10000;
+    fault_tolerances[FaultCode_CURRENT_SENSOR_COMM]         = 10;
+    fault_tolerances[FaultCode_OVER_CURRENT]                = 1;
+
+    // ideally this would start low, but the FSAE rules say faults must latch
+    // at the hardware level so we have to start with the true or the car will never drive
+    is_driving_allowed = true;
+}
+
+/**
+ * Update active fault timers, shut down car if any expire.
+ */
+void DriveMonitor_1kHz(void)
+{
+    // driving is now allowed, if no unsafe conditions detected below
+    bool driving_allowed = true;
+
+    // check to see if any faults have been active for too long
+    for (int code = 0; code < FaultCode_NUM; code++)
+    {   
+        // if the fault is active or there is no tolerance for it
+        if (FaultManager_is_fault_active(code) || (fault_tolerances[code] == 0))
+        {
+            // fault is active, increment counter + check for expiration
+            if (incr_to_limit(&active_fault_timers[code], fault_tolerances[code]))
+            {
+                driving_allowed = false;
+            }
+        }
+        else
+        {
+            // fault is not active, reset counter
+            active_fault_timers[code] = 0;
+        }
+    }
+
+    if (driving_allowed)
+    {
+        // no timers are expired
+        // therefore an unsafe driver condition is not present
+        ShutdownLine_nominal();
+    }
+    else
+    {
+        // unsafe driver condition is present
+        ShutdownLine_indicate_fault();
+    }
+
+    is_driving_allowed = driving_allowed;
+}
+/**
+ * Return false if the shutdown line is active, true otherwise.
+ */
+bool DriveMonitor_is_driving_allowed(void)
+{
+    return is_driving_allowed;
+}

--- a/src/app/DriveMonitor/DriveMonitor.h
+++ b/src/app/DriveMonitor/DriveMonitor.h
@@ -1,0 +1,29 @@
+#ifndef DRIVE_MONITOR_H
+#define DRIVE_MONITOR_H
+
+#include <stdbool.h>
+
+/**
+ * All logic for controlling the shutdown line based on active faults.
+ * 
+ * Some faults trigger shutdown if they are active for any amount of time,
+ * others have a tolerance. Tolerance in this context is defined as a maximum amount of 
+ * time that is acceptable for the fault to be active at a time.
+ */
+
+/**
+ * Initialize fault tolerances and active fault timers.
+ */
+void DriveMonitor_init(void);
+
+/**
+ * Update active fault timers, shut down car if any expire.
+ */
+void DriveMonitor_1kHz(void);
+
+/**
+ * Return false if the shutdown line is active, true otherwise.
+ */
+bool DriveMonitor_is_driving_allowed(void);
+
+#endif // DRIVE_MONITOR_H

--- a/src/app/DriveMonitor/test_DriveMonitor.c
+++ b/src/app/DriveMonitor/test_DriveMonitor.c
@@ -1,0 +1,54 @@
+#include "unity.h"
+
+#include "DriveMonitor.h"
+
+#include "MockFaultManager.h"
+#include "MockShutdownLine.h"
+
+/**
+ * Verify the DriveMonitor doesn't assert the shutdown line when no faults
+ * are present.
+ */
+void test_DriveMonitor_nominal(void)
+{
+    DriveMonitor_init();
+
+    // run for 10 seconds with no faults
+    for (int ms = 0; ms < 10000; ms++)
+    {
+        // simulate nominal conditions
+        for (int code = 0; code < FaultCode_NUM; code++)
+        {
+            FaultManager_is_fault_active_ExpectAnyArgsAndReturn(false);
+        }
+        ShutdownLine_nominal_Expect();
+        DriveMonitor_1kHz();
+        char err_msg[100];
+        sprintf(err_msg, "Driving was not allowed with no fault conditions.");
+        TEST_ASSERT_MESSAGE(DriveMonitor_is_driving_allowed() == true, err_msg);
+
+        resetTest();
+    }
+}
+
+/**
+ * Verify that an overcurrent event immediately shuts down the car.
+ */
+void test_DriveMonitor_shutdown_overcurrent(void)
+{
+    char err_msg[100];
+
+    DriveMonitor_init();
+
+    // "set" the overcurrent fault but no others
+    for (int code = 0; code < FaultCode_NUM; code++)
+    {
+        FaultManager_is_fault_active_ExpectAndReturn(code, code == FaultCode_OVER_CURRENT ? true : false);
+    }
+
+    ShutdownLine_indicate_fault_Expect();
+    DriveMonitor_1kHz();
+
+    sprintf(err_msg, "DriveMonitor did not indicate over current fault.");
+    TEST_ASSERT_MESSAGE(DriveMonitor_is_driving_allowed() == false, err_msg);
+}

--- a/src/common/counters/counters.c
+++ b/src/common/counters/counters.c
@@ -1,6 +1,6 @@
 #include "counters.h"
 
-bool counter_incr(int* counter, int upper_limit)
+bool incr_to_limit(int* counter, int upper_limit)
 {
     bool retval = false;
     (*counter)++;
@@ -14,7 +14,7 @@ bool counter_incr(int* counter, int upper_limit)
     return retval;
 }
 
-bool counter_decr(int* counter, int lower_limit)
+bool decr_to_limit(int* counter, int lower_limit)
 {
     bool retval = false;
     (*counter)--;

--- a/src/common/counters/counters.h
+++ b/src/common/counters/counters.h
@@ -20,7 +20,7 @@
  * upper_limit [in] - if counter is at or above this limit, don't increment
  * return true if counter is at or above upper_limit, false otherwise
  */
-bool counter_incr(int* counter, int upper_limit);
+bool incr_to_limit(int* counter, int upper_limit);
 
 
 /**
@@ -29,6 +29,6 @@ bool counter_incr(int* counter, int upper_limit);
  * lower_limit [in] - if counter is at or below this limit, don't decrement
  * return true if counter is at or below lower_limit, false otherwise
  */
-bool counter_decr(int* counter, int lower_limit);
+bool decr_to_limit(int* counter, int lower_limit);
 
 #endif // COUNTERS_H


### PR DESCRIPTION
This module contains the logic for when/why to assert the shutdown line.

Operation:
-It does this by establishing a quantity of time for each fault code in milliseconds, known as the fault's tolerance. If a given fault code stays asserted by the FaultManager for longer than its tolerance, the DriveMonitor asserts the shutdown line.
-A period of time, known as the startup time, in milliseconds, is established. The DriveMonitor must wait for this time after initialization to de-assert the shutdown line, which begins asserted on power-on. This mechanism allows for faults that take time to detect to be detected before allowing a driving condition. Without the startup time, the microcontroller could reset when a fault condition is present, and then allow driving briefly before the fault is detected by the new runtime.
-Fault codes have their tolerance initialized as zero, which means when a new fault code is added, the developer must also initialize this tolerance in DriveMonitor, or the shutdown line will always be asserted if the code is compiled and ran.

Unit tests performed:
-Startup time verification, to enforce a startup time mechanic
-Overcurrent immediate fault verification. There should be no time given for an overcurrent event to correct itself since its dangerous. Future immanently dangerous faults should have similar tests added for DriveMonitor.

Currently targets FaultManager branch, which should be merged first.